### PR TITLE
Setup test framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ rvm:
   - 2.3.3
 sudo: false
 cache: bundler
+script:
+  - bundle exec rake
+  - bash <(curl -fsSL https://github.com/everypolitician/ensure-regression-tests/raw/v0.1.0/ensure-regression-tests)

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'rake'
 gem 'rubocop'
 gem 'scraped', github: 'everypolitician/scraped'
 gem 'scraped_page_archive', github: 'everypolitician/scraped_page_archive'
+gem 'scraper_test', github: 'everypolitician/scraper_test'
 gem 'scraperwiki', github: 'openaustralia/scraperwiki-ruby',
                    branch: 'morph_defaults'
 gem 'table_unspanner', github: 'everypolitician/table_unspanner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,16 @@ GIT
       vcr-archive (~> 0.3.0)
 
 GIT
+  remote: https://github.com/everypolitician/scraper_test.git
+  revision: a8a6c795ea1544bc95e2f7a1dbb132ba8c80ed98
+  specs:
+    scraper_test (0.1.0)
+      minitest (~> 5.0)
+      pry
+      vcr (>= 3.0.3)
+      webmock (>= 2.0)
+
+GIT
   remote: https://github.com/everypolitician/table_unspanner.git
   revision: a70a98a104a75b470f4ea339fdd728366a40b4d8
   specs:
@@ -105,6 +115,7 @@ DEPENDENCIES
   rubocop
   scraped!
   scraped_page_archive!
+  scraper_test!
   scraperwiki!
   table_unspanner!
   vcr
@@ -114,4 +125,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.13.6
+   1.14.6

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
-require 'rubocop/rake_task'
 
+require 'rubocop/rake_task'
 RuboCop::RakeTask.new
 
-task default: %w(rubocop)
+require 'scraper_test'
+ScraperTest::RakeTask.new.install_tasks
+
+task test: 'test:data'
+task default: %w(rubocop test)


### PR DESCRIPTION
This PR ensures that Rake runs checks against any yaml files in tests/data using scraper_test (https://github.com/everypolitician/scraper_test)

It also sets the repo up for custom tests so that a subset of data of MembersPage can be tested.

This PR replaces the first three commits in https://github.com/everypolitician-scrapers/tunisia-marsad/pull/3